### PR TITLE
Bump Dune dependency, setup Fmt through Cmdliner

### DIFF
--- a/dune
+++ b/dune
@@ -1,4 +1,4 @@
 (executable
  (public_name opam-dune-lint)
  (name main)
- (libraries astring fmt fmt.tty bos opam-format opam-state cmdliner stdune sexplib str))
+ (libraries astring fmt fmt.cli fmt.tty bos opam-format opam-state cmdliner stdune sexplib str))

--- a/dune-project
+++ b/dune-project
@@ -17,7 +17,7 @@
   (sexplib (>= v0.14.0))
   (cmdliner (>= 1.1.0))
   (stdune (>= 3.0))
-  (ocaml (>= 4.10.0))
+  (ocaml (>= 4.13.0))
   (bos (>= 0.2.0))
   (fmt (>= 0.8.9))
   (opam-state (>= 2.0.9))

--- a/dune-project
+++ b/dune-project
@@ -1,12 +1,15 @@
-(lang dune 2.7)
+(lang dune 3.7)
 (name opam-dune-lint)
+
 (formatting disabled)
 (generate_opam_files true)
+(cram enable)
+
 (source (github ocurrent/opam-dune-lint))
 (authors "talex5@gmail.com")
 (maintainers "talex5@gmail.com")
 (license ISC)
-(cram enable)
+
 (package
  (name opam-dune-lint)
  (synopsis "Ensure dune and opam dependencies are consistent")

--- a/dune_project.ml
+++ b/dune_project.ml
@@ -96,7 +96,7 @@ let update (changes:(_ * Change.t list) Paths.t) (t:t) =
     match package_name items with
     | None -> failwith "Missing 'name' in (package)!"
     | Some name ->
-      match Paths.find_opt (name ^ ".opam") changes with
+      match Paths.find_opt (String.cat name ".opam") changes with
       | None -> items
       | Some (_opam, changes) -> update_or_create "depends" (apply_changes ~changes) items
   in

--- a/main.ml
+++ b/main.ml
@@ -142,7 +142,7 @@ let confirm_with_user () =
     false
   )
 
-let main force dir =
+let main () force dir =
   Sys.chdir dir;
   let index = Index.create () in
   let old_opam_files = get_opam_files () in
@@ -178,6 +178,14 @@ let main force dir =
 
 open Cmdliner
 
+let setup_fmt style_renderer =
+  Fmt_tty.setup_std_outputs ?style_renderer ();
+  ()
+
+let setup_fmt =
+  let docs = Manpage.s_common_options in
+  Term.(const setup_fmt $ Fmt_cli.style_renderer ~docs ())
+
 let dir =
   Arg.value @@
   Arg.pos 0 Arg.dir "." @@
@@ -196,9 +204,7 @@ let force =
 let cmd =
   let doc = "keep dune and opam files in sync" in
   let info = Cmd.info "opam-dune-lint" ~doc in
-  let term = Term.(const main $ force $ dir) in
+  let term = Term.(const main $ setup_fmt $ force $ dir) in
   Cmd.v info term
 
-let () =
-  Fmt_tty.setup_std_outputs ();
-  exit @@ Cmd.eval cmd
+let () = exit @@ Cmd.eval cmd

--- a/opam-dune-lint.opam
+++ b/opam-dune-lint.opam
@@ -14,7 +14,7 @@ depends: [
   "sexplib" {>= "v0.14.0"}
   "cmdliner" {>= "1.1.0"}
   "stdune" {>= "3.0"}
-  "ocaml" {>= "4.10.0"}
+  "ocaml" {>= "4.13.0"}
   "bos" {>= "0.2.0"}
   "fmt" {>= "0.8.9"}
   "opam-state" {>= "2.0.9"}

--- a/opam-dune-lint.opam
+++ b/opam-dune-lint.opam
@@ -9,7 +9,7 @@ license: "ISC"
 homepage: "https://github.com/ocurrent/opam-dune-lint"
 bug-reports: "https://github.com/ocurrent/opam-dune-lint/issues"
 depends: [
-  "dune" {>= "2.7"}
+  "dune" {>= "3.7"}
   "astring" {>= "0.8.5"}
   "sexplib" {>= "v0.14.0"}
   "cmdliner" {>= "1.1.0"}


### PR DESCRIPTION
I'm not sure if bumping Dune will prevent opam-dune-lint from running in more places, but it could be helpful while working on opam-dune-lint.
This also exposes Fmt options to Cmdliner.